### PR TITLE
fix the input shape to match (:, timesteps, feature) of keras' lstm

### DIFF
--- a/StockPricesPredictionProject/pricePredictionLSTM.py
+++ b/StockPricesPredictionProject/pricePredictionLSTM.py
@@ -50,12 +50,12 @@ trainX, trainY = create_dataset(train, look_back)
 testX, testY = create_dataset(test, look_back)
 
 # reshape input to be [samples, time steps, features]
-trainX = np.reshape(trainX, (trainX.shape[0], 1, trainX.shape[1]))
-testX = np.reshape(testX, (testX.shape[0], 1, testX.shape[1]))
+trainX = np.reshape(trainX, (trainX.shape[0], trainX.shape[1], 1))
+testX = np.reshape(testX, (testX.shape[0], testX.shape[1], 1))
 
 # create and fit the LSTM network, optimizer=adam, 25 neurons, dropout 0.1
 model = Sequential()
-model.add(LSTM(25, input_shape=(1, look_back)))
+model.add(LSTM(25, input_shape=(look_back, 1)))
 model.add(Dropout(0.1))
 model.add(Dense(1))
 model.compile(loss='mse', optimizer='adam')


### PR DESCRIPTION
The input shape of an LSTM layer should be a tensor of shape `(:, timesteps, feature)` as specified in the [documentation](https://keras.io/api/layers/recurrent_layers/lstm/).

This change ensures that the input shape matches the expected format so that the LSTM layer processes the inputs recurrently over time steps.

Previously, the code passed inputs with the shape (:, 1, look_back), treating each sample as a `look_back`-dimensional feature vector. This caused the LSTM to function incorrectly.

**Impact of the Fix:**

```
Before the fix:
Train Score: 0.50 RMSE
Test Score: 13.97 RMSE

After the fix:
Train Score: 0.50 RMSE
Test Score: 2.27 RMSE
```

This fix significantly improves the model's performance on the test set, indicating that the LSTM now correctly learns temporal patterns.
